### PR TITLE
Update Dockerfile to take vpc-controller source code from submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cloud-provider-vpc-controller"]
+	path = cloud-provider-vpc-controller
+	url = https://github.com/openshift/cloud-provider-vpc-controller

--- a/openshift-hack/images/Dockerfile.openshift
+++ b/openshift-hack/images/Dockerfile.openshift
@@ -1,9 +1,8 @@
 # Build vpcctl binary
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.9 as vpc-builder
 WORKDIR /build
-RUN git clone https://github.com/openshift/cloud-provider-vpc-controller && \
-    cd cloud-provider-vpc-controller && \
-    make build-linux
+COPY cloud-provider-vpc-controller .
+RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o vpcctl cmd/main.go
 
 # Build IBM cloud controller manager binary
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.9 as ccm-builder
@@ -14,6 +13,6 @@ RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o ibm-cloud-controller-manager .
 # Assemble the final image
 FROM registry.ci.openshift.org/ocp/4.9:base
 LABEL description="IBM Cloud Controller Manager"
-COPY --from=vpc-builder /build/cloud-provider-vpc-controller/vpcctl-linux /bin/vpcctl
+COPY --from=vpc-builder /build/vpcctl /bin/vpcctl
 COPY --from=ccm-builder /build/ibm-cloud-controller-manager /bin/ibm-cloud-controller-manager
 ENTRYPOINT [ "/bin/ibm-cloud-controller-manager" ]


### PR DESCRIPTION
For IBM CCM to work correctly its image must contain `vpcctl` binary, that is built from a standalone repository: https://github.com/openshift/cloud-provider-vpc-controller. This PR adds this repository code as a git submodule, that will be used later during Container image building.