### PR TITLE
UPSTREAM: <carry>: Update dockerfile to go 1.17

### DIFF
--- a/openshift-hack/images/Dockerfile.openshift
+++ b/openshift-hack/images/Dockerfile.openshift
@@ -1,11 +1,11 @@
 # Build vpcctl binary
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.10 AS vpc-builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS vpc-builder
 WORKDIR /build
 COPY cloud-provider-vpc-controller .
 RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o vpcctl cmd/main.go
 
 # Build IBM cloud controller manager binary
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.10 AS ccm-builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS ccm-builder
 WORKDIR /build
 COPY . .
 RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o ibm-cloud-controller-manager .


### PR DESCRIPTION
Update the Dockerfile used to build the CCM, and vpc-controller,
to Golang 1.17, to match the opensource requirements.