### PR TITLE
OCPBUGS-24644: Add Snyk file to exclude vendor directory on scan

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,6 @@
+# References:
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+# https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    - vendor/**


### PR DESCRIPTION
Hello! This is a PR to add a snyk file to exclude the vendors folder while scanning the repo. Thanks!